### PR TITLE
Support crystal 0.19.4

### DIFF
--- a/channel-select/channel-select.cr
+++ b/channel-select/channel-select.cr
@@ -14,13 +14,18 @@ ch2 = generator(1.5)
 ch3 = generator(5)
 
 loop do
-  index, value = Channel.select(ch1.receive_op, ch2.receive_op, ch3.receive_op)
+  index, value = Channel.select(
+    ch1.receive_select_action,
+    ch2.receive_select_action,
+    ch3.receive_select_action
+  )
+
   case index
   when 0
-    int = value as typeof(ch1.receive)
+    int = value.as(typeof(ch1.receive))
     puts "Int: #{value}"
   when 1
-    float = value as typeof(ch2.receive)
+    float = value.as(typeof(ch2.receive))
     puts "Float: #{value}"
   when 2
     break

--- a/def/def.cr
+++ b/def/def.cr
@@ -15,7 +15,7 @@ puts "ali".tsk
 def foo(x : Int, y : Float)
 end
 
-def foo(x, y = 1 : Int32, z = 2 : Int64)
+def foo(x, y : Int32 = 1, z : Int64 = 2)
   x + y + z
 end
 

--- a/json/json.cr
+++ b/json/json.cr
@@ -5,7 +5,7 @@ puts "askn".to_json
 puts 1.to_json
 puts 12.14.to_json
 puts ["apple", "peach", "pear"].to_json
-puts Hash{"apple": 5, "lettuce": 7}.to_json
+puts Hash{"apple" => 5, "lettuce" => 7}.to_json
 
 # json_object
 # json_array

--- a/struct/struct.cr
+++ b/struct/struct.cr
@@ -4,25 +4,32 @@ end
 Foo(Int32)
 
 # ---
-struct Fo
+struct Foo
 end
 
-struct Bar < Fo
+# struct Bar < Foo
+# end
+# Error in ./struct/struct.cr:10: can't extend non-abstract struct Foo
+
+abstract struct AbstractFoo
+end
+
+struct Bar < AbstractFoo
 end
 
 # ---
 struct Test
-  def initialize(@test)
+  def initialize(@test : String)
   end
 end
 
-Test.new(nil)
+Test.new("foo")
 
 # ---
 struct User
   property name, age
 
-  def initialize(@name, @age)
+  def initialize(@name : String, @age : Int32)
   end
 
   def print

--- a/tickers/tickers.cr
+++ b/tickers/tickers.cr
@@ -1,5 +1,5 @@
 class Ticker
-  def initialize(@duration)
+  def initialize(@duration : Float64)
     @c = Channel(Nil).new
   end
 
@@ -16,7 +16,7 @@ class Ticker
     @c.close
   end
 
-  def each &block
+  def each(&block)
     start_timer
     spawn do
       until @c.closed?

--- a/variables/variables.cr
+++ b/variables/variables.cr
@@ -3,20 +3,32 @@ puts a
 a = 3
 puts a
 
-x :: String
-x = "osman"
-puts x
-# tek satırda atama yapma ?
+# Currently type restrictions are not allowed for local variables
+# so we need the next few examples in a class
 
-e :: Int32
-puts e
-# e = "osman"
-# Error in ./variables.cr:11: type must be Int32, not (String | Int32)
+class WrapperClass
+  @x : String
+  @e : Int32
+  @y : Int32 | String
 
-# y :: Int32 | String
-# puts y # segmentation fault
+  def initialize
+    @x = "osman"
+    puts @x
 
-# tipi ile beraber çoklu atama ?
+    @e = 1
+    puts @e
+
+    # @e = "osman"
+    # in ./variables/variables.cr:20: instance variable '@e' of WrapperClass must be Int32, not String
+    @y = 1
+    @y = "osman"
+    puts @y
+  end
+end
+
+WrapperClass.new
+
+# Multiple assignments in a single line
 b, c = 1, 2
 puts b, c
 


### PR DESCRIPTION
Hi,

some of the examples refused to compile with newer versions of crystal
(I used version 0.19.4, 0.18.\* have lead to similar results)
so I tried my best to update them.

I am not sure if my fix for `variables/variables.cr`
is good, but there does not seem to be another way.
