### PR TITLE
all examples now run on v0.23

### DIFF
--- a/abstract/abstract.cr
+++ b/abstract/abstract.cr
@@ -1,4 +1,9 @@
-class Foo
+# class Foo
+#   abstract def foo
+# end
+# Error in abstract/abstract.cr:2: can't define abstract def on non-abstract class
+
+abstract class Foo
   abstract def foo
 end
 
@@ -16,13 +21,13 @@ end
 
 # ---
 
-abstract class Geometry
-  abstract def area
-  abstract def perim
+abstract class Geometry(T)
+  abstract def area : T
+  abstract def perim : T
 end
 
-class Rect < Geometry
-  def initialize(@width, @height)
+class Rect < Geometry(Int32)
+  def initialize(@width : T, @height : T)
   end
 
   def area

--- a/buffered-channel/buffered-channel.cr
+++ b/buffered-channel/buffered-channel.cr
@@ -4,5 +4,5 @@ ch.send 5
 
 2.times {
   puts "Yo"
-  ch.receive
+  puts ch.receive
 }

--- a/channel-select/channel-select.cr
+++ b/channel-select/channel-select.cr
@@ -1,4 +1,4 @@
-def generator(n : T)
+def generator(n : T) forall T
   channel = Channel(T).new
   spawn do
     loop do

--- a/channel-synchronization/channel-synchronization.cr
+++ b/channel-synchronization/channel-synchronization.cr
@@ -1,12 +1,16 @@
-def worker(done : Channel(Bool))
-  puts "working"
-  sleep 2
-  puts "done"
+def worker(count : Int32, done : Channel(Bool))
+  puts "working #{count}"
+  sleep count
+  puts "done #{count}"
   done.send true
 end
 
 done = Channel(Bool).new
-spawn worker(done)
-
+worker_count = 10
+worker_count.times do |count|
+  spawn worker(count, done)
+end
 # eğer bu satırı silersek başlamasını beklemeden çıkar
-done.receive
+worker_count.times do
+  done.receive
+end

--- a/complex/complex.cr
+++ b/complex/complex.cr
@@ -1,0 +1,11 @@
+require "colorize"
+require "complex"
+x1 = Complex.new(1, 0)
+x2 = Complex.new(2, 1)
+pp x1
+pp x2
+puts
+p "x 1 + x2 = #{x1 + x2}"
+p "x1 - x2 = #{x1 - x2}"
+p "x1 * x2 = #{x1 * x2}"
+p "x1 / x2 = #{x1 / x2}"

--- a/container/container.cr
+++ b/container/container.cr
@@ -1,0 +1,14 @@
+class Container(T)
+
+  def initialize(@values : T)
+    pp @values
+    pp typeof(@values)
+  end
+end
+
+Container.new([1,2,3])
+Container.new([1.0, 3.0, 4.0])
+value = [[1, 2], [4,3,2],[1]]
+Container.new(value)
+value = [[1.0, 4.5], [2.2, 0.0]]
+Container.new(value)

--- a/def/def.cr
+++ b/def/def.cr
@@ -19,7 +19,7 @@ def foo(x, y : Int32 = 1, z : Int64 = 2)
   x + y + z
 end
 
-def foo(x : T)
+def foo(x : T) forall T
 end
 
 foo(3) # x = 3, T = Int32

--- a/free/free.cr
+++ b/free/free.cr
@@ -1,0 +1,19 @@
+class Foo
+  def initialize
+    @x = 10
+    @y = "some string"
+    puts "initialized"
+  end
+
+  def finalize
+    puts "Never called"
+  end
+end
+
+foo = Foo.new
+p foo # => #<Foo:0x10be27fd0 @x=10>
+GC.free(Pointer(Void).new(foo.object_id)) # This line frees the memory
+#p foo # => #<Foo:0x10be27fd0 @x=1>
+p foo.class
+p foo = nil
+p foo.class

--- a/json/json.cr
+++ b/json/json.cr
@@ -10,16 +10,16 @@ puts Hash{"apple" => 5, "lettuce" => 7}.to_json
 # json_object
 # json_array
 # field
-result = String.build do |io|
-  io.json_object do |object|
-    object.field "address", "Crystal Road 1234"
-    object.field "location" do
-      io.json_array do |array|
-        array << 12.3
-        array << 34.5
+result = JSON.build do |json|
+	json.object do
+  	json.field "address", "Crystal Road 1234"
+    json.field "location" do
+      json.array do
+        json.number 12.3
+        json.number 34.5
       end
     end
-  end
+	end
 end
 puts result # => %({"address":"Crystal Road 1234","location":[12.3,34.5]})
 

--- a/named_tuple/named_tuple.cr
+++ b/named_tuple/named_tuple.cr
@@ -1,0 +1,7 @@
+strings = {string_1: "String 1",
+           string_2: "String 2",
+           string_3: "String 3"}
+
+puts strings[:string_1]
+puts strings[:string_2]
+puts strings[:string_3]

--- a/pointer_like_helper_structure/pointer_like_helper_structure.cr
+++ b/pointer_like_helper_structure/pointer_like_helper_structure.cr
@@ -1,0 +1,32 @@
+# License is MIT, though I always appreciate a short in-source comment like I prepared.
+# But as it's MIT, you may omit it of course.
+
+# Helper structure which acts like a pointer, but allows direct access to the
+# underlying object by delegating almost all calls on it to the pointee.
+#
+# It's best compared to C's -> operator.
+#
+# (Based on https://gist.github.com/Papierkorb/c46e205e27e4c341965438b18e28e09e)
+struct Ref(T)
+  getter ptr : Pointer(T)
+
+  def self.create
+    new(T.new)
+  end
+
+  def initialize(@ptr : Pointer(T))
+  end
+
+  def initialize(obj : Reference)
+    @ptr = pointerof(obj)
+  end
+
+  def initialize(val : Value)
+    @ptr = Pointer(T).malloc
+    @ptr.value = val
+  end
+
+  macro method_missing(call)
+    @ptr.value.{{ call }}
+  end
+end

--- a/run_all.cr
+++ b/run_all.cr
@@ -1,0 +1,15 @@
+require "colorize"
+files = Dir["./**/**.cr"]
+
+files.each do |x|
+  next if x == "./run_all.cr"
+  print "--------"
+  x.size.times { print "-" }
+  puts
+  puts "Running #{x}".colorize(:blue)
+  op = system("cd #{File.dirname(x)} && crystal #{File.basename(x)}")
+  unless op
+    puts "Error detected - exiting!".colorize(:red)
+    exit 1
+  end
+end

--- a/spawn/spawn.cr
+++ b/spawn/spawn.cr
@@ -7,7 +7,7 @@ end
 
 xxx("normal")
 
-spawn xxx "spawn"
+spawn xxx("spawn")
 
 spawn do
   sleep 3

--- a/string_object/string_object.cr
+++ b/string_object/string_object.cr
@@ -1,0 +1,37 @@
+struct StringObj
+  getter string_1
+  getter string_2
+  getter string_3
+  getter string_4
+  getter string_5
+  getter string_6
+  getter string_7
+  getter string_8
+  getter string_9
+  getter string_10
+
+  def initialize
+    @string_1 = "str.string_1"
+    @string_2 = "str.string_2"
+    @string_3 = "str.string_3"
+    @string_4 = "str.string_4"
+    @string_5 = "str.string_5"
+    @string_6 = "str.string_6"
+    @string_7 = "str.string_7"
+    @string_8 = "str.string_8"
+    @string_9 = "str.string_9"
+    @string_10 = "str.string_10"
+  end
+end
+
+str = StringObj.new
+p str.string_1
+p str.string_2
+p str.string_3
+p str.string_4
+p str.string_5
+p str.string_6
+p str.string_7
+p str.string_8
+p str.string_9
+p str.string_10

--- a/subclasses/subclasses_discovery_macro.cr
+++ b/subclasses/subclasses_discovery_macro.cr
@@ -1,0 +1,24 @@
+class Base
+  SUBCLASSES = {% begin %}
+    [
+      {% for clazz in Base.subclasses %}
+        {{clazz.methods.map(&.name.stringify)}} of String,
+      {% end %}
+    ] of Array(String)
+  {% end %}
+end
+
+class Foo < Base
+  def foo
+  end
+
+  def bar
+  end
+end
+
+class Bar < Base
+  def baz
+  end
+end
+
+puts Base::SUBCLASSES

--- a/type_restriction/type_restriction.cr
+++ b/type_restriction/type_restriction.cr
@@ -1,0 +1,13 @@
+class Foo; end
+class Bar < Foo; end
+class Cux < Foo; end
+class MyClass
+  def initialize(@foo : Foo)
+  end
+end
+
+
+MyClass.new(Foo.new)
+bar = Bar.new
+MyClass.new(bar)
+MyClass.new(Cux.new)

--- a/values/values.cr
+++ b/values/values.cr
@@ -1,4 +1,4 @@
-puts "crystal" + "programming"
+puts "crystal" + " " + "programming"
 
 puts "1+1 = #{1 + 1}"
 puts "7.0/3.0 = #{7.0 / 3.0}"


### PR DESCRIPTION
### channel-select 
+ ``` ... in channel-select/channel-select.cr:1: undefined constant T ```

>
  ```
  <FromGitter> <mverzilli> the T there is a free variable, so it needs to be quantified  
  <FromGitter> <sdogruyol> forall is kind of underdocumented :P  
```


### json
+ ``` undefined method 'json_object' for String::Builder ```
>
  ``` JSON has new syntax now. ```  

