### PR TITLE
Update time-formatting-parsing.cr

### DIFF
--- a/time-formatting-parsing/time-formatting-parsing.cr
+++ b/time-formatting-parsing/time-formatting-parsing.cr
@@ -1,5 +1,5 @@
-puts Time.parse("2012-11-01 22:08:12", "%F %T")
+puts Time.parse("2012-11-01 22:08:12", "%F %T", Time::Location.local)
 
-puts Time.parse("Fri Oct 31 23:00:24 2014", "%c")
+puts Time.parse("Fri Oct 31 23:00:24 2014", "%c", Time::Location.local)
 
-puts Time.parse("20150624", "%Y%m%d")
+puts Time.parse("20150624", "%Y%m%d", Time::Location.local)


### PR DESCRIPTION
Err: 
```
wrong number of arguments for 'Time.parse' (given 2,
expected 3)
Overloads are:
 - Time.parse(time : String, pattern : String, location : Location)

puts Time.parse("2012-11-01 22:08:12", "%F %T")
```